### PR TITLE
fix: use earliest execution epoch

### DIFF
--- a/src/lib/0x-treasury/create-proposal.ts
+++ b/src/lib/0x-treasury/create-proposal.ts
@@ -5,19 +5,19 @@ import {ZrxTreasury, StakingProxy} from "../../../contract-libs";
 import {IZrxTreasury} from "../../../contract-libs/zrx-protocol/ZrxTreasury";
 
 export async function encodeProposal(
-  treasuryAddress: string, 
-  description: string, 
-  actions: IZrxTreasury.ProposedActionStruct[], 
+  treasuryAddress: string,
+  description: string,
+  actions: IZrxTreasury.ProposedActionStruct[],
   operatedPoolIds: string[]
 ) {
   const treasury = <ZrxTreasury>await ethers.getContractAt(ZrxTreasuryAbi, treasuryAddress);
-  
+
   const stakingProxyAddress = await treasury.stakingProxy();
   const stakingProxy = <StakingProxy>await ethers.getContractAt(StakingProxyAbi, stakingProxyAddress);
 
   const currentEpoch = await stakingProxy.currentEpoch().then(e => e.toNumber());
   const votingEpoch = currentEpoch + 2;
-  const executionEpoch = votingEpoch + 1;
+  const executionEpoch = votingEpoch;
 
   const callData = treasury.interface.encodeFunctionData('propose', [
     actions,

--- a/src/lib/0x-treasury/submit-proposal.ts
+++ b/src/lib/0x-treasury/submit-proposal.ts
@@ -5,19 +5,19 @@ import {ZrxTreasury, StakingProxy} from "../../../contract-libs";
 import {IZrxTreasury} from "../../../contract-libs/zrx-protocol/ZrxTreasury";
 
 export async function submitProposal(
-  treasuryAddress: string, 
-  description: string, 
-  actions: IZrxTreasury.ProposedActionStruct[], 
+  treasuryAddress: string,
+  description: string,
+  actions: IZrxTreasury.ProposedActionStruct[],
   operatedPoolIds: string[]
 ) {
   const treasury = <ZrxTreasury>await ethers.getContractAt(ZrxTreasuryAbi, treasuryAddress);
-  
+
   const stakingProxyAddress = await treasury.stakingProxy();
   const stakingProxy = <StakingProxy>await ethers.getContractAt(StakingProxyAbi, stakingProxyAddress);
 
   const currentEpoch = await stakingProxy.currentEpoch().then(e => e.toNumber());
   const votingEpoch = currentEpoch + 2;
-  const executionEpoch = votingEpoch + 1;
+  const executionEpoch = votingEpoch;
 
   return treasury.propose(
     actions,
@@ -26,4 +26,3 @@ export async function submitProposal(
     operatedPoolIds,
   );
 }
-


### PR DESCRIPTION
resolves #1 

#### :notebook: Overview
The proposed changes set the execution epoch in the proposal inputs equal to the voting epoch, as the minimum epoch lag required by the ZRX Treasury.

- use same epoch as voting epoch for execution epoch, as that is the minimum required by the ZRX Treasury
- minor linting